### PR TITLE
[✨ feat] 멤버 이름 구현

### DIFF
--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -53,7 +53,30 @@ public class MemberName {
 
     private void validateCharacter(String value) {
         if (value.matches(SPECIAL_LETTERS)) {
-            throw new IllegalArgumentException("특수문자는 이름 구성에 포함시킬 수 없습니다.");
+            throw new IllegalArgumentException("특수문자는 이름 구성에 포함될 수 없습니다.");
+        }
+
+        for (int cp : value.codePoints().toArray()) {
+            if (isInvalidCharacter(cp)) {
+                throw new IllegalArgumentException("허용되지 않은 문자가 포함되어 있습니다.");
+            }
         }
     }
+
+    private boolean isInvalidCharacter(int cp) {
+        return !(isKorean(cp) || isEnglish(cp) || Character.isDigit(cp) || Character.isSpaceChar(cp) || isEmoji(cp));
+    }
+
+    private boolean isKorean(int cp) {
+        return cp >= 0xAC00 && cp <= 0xD7A3;
+    }
+
+    private boolean isEnglish(int cp) {
+        return (cp >= 'a' && cp <= 'z') || (cp >= 'A' && cp <= 'Z');
+    }
+
+    private boolean isEmoji(int cp) {
+        return (cp >= 0x1F300 && cp <= 0x1FAFF) || (cp >= 0x2600 && cp <= 0x26FF);
+    }
+
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -56,11 +56,12 @@ public class MemberName {
             throw new IllegalArgumentException("특수문자는 이름 구성에 포함될 수 없습니다.");
         }
 
-        for (int cp : value.codePoints().toArray()) {
-            if (isInvalidCharacter(cp)) {
-                throw new IllegalArgumentException("허용되지 않은 문자가 포함되어 있습니다.");
-            }
-        }
+        value.codePoints()
+                .filter(this::isInvalidCharacter)
+                .findFirst()
+                .ifPresent(cp -> {
+                    throw new IllegalArgumentException("허용되지 않은 문자가 포함되어 있습니다.");
+                });
     }
 
     private boolean isInvalidCharacter(int cp) {

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 public class MemberName {
 
     private static final int MAX_LENGTH = 10;
+    private static final String SPECIAL_LETTERS = ".*[~`!@#$%^&*()\\-_=+\\[{\\]}\\\\|;:'\",<.>/?].*";
 
     private final String value;
 
@@ -31,6 +32,7 @@ public class MemberName {
     private void validate(String value) {
         validateNotNullOrBlank(value);
         validateLength(value);
+        validateCharacter(value);
     }
 
     private void validateNotNullOrBlank(String value) {
@@ -46,6 +48,12 @@ public class MemberName {
     private void validateLength(String value) {
         if (value.length() > MAX_LENGTH) {
             throw new IllegalArgumentException("이름은 10자를 초과할 수 없습니다.");
+        }
+    }
+
+    private void validateCharacter(String value) {
+        if (value.matches(SPECIAL_LETTERS)) {
+            throw new IllegalArgumentException("특수문자는 이름 구성에 포함시킬 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -53,15 +53,15 @@ public class MemberName {
 
     private void validateCharacter(String value) {
         if (value.matches(SPECIAL_LETTERS)) {
-            throw new IllegalArgumentException("특수문자는 이름 구성에 포함될 수 없습니다.");
+            throw new IllegalArgumentException("특수문자는 이름 구성에 사용될 수 없습니다.");
         }
 
-        value.codePoints()
-                .filter(this::isInvalidCharacter)
-                .findFirst()
-                .ifPresent(cp -> {
-                    throw new IllegalArgumentException("허용되지 않은 문자가 포함되어 있습니다.");
-                });
+        for (int cp : value.codePoints().toArray()) {
+            if (isInvalidCharacter(cp)) {
+                String invalidChar = new String(Character.toChars(cp));
+                throw new IllegalArgumentException("이름에 허용되지 않은 문자(" + invalidChar + ")가 포함되어 있습니다.");
+            }
+        }
     }
 
     private boolean isInvalidCharacter(int cp) {
@@ -77,7 +77,14 @@ public class MemberName {
     }
 
     private boolean isEmoji(int cp) {
-        return (cp >= 0x1F300 && cp <= 0x1FAFF) || (cp >= 0x2600 && cp <= 0x26FF);
+        return (cp >= 0x1F600 && cp <= 0x1F64F)
+                || (cp >= 0x1F300 && cp <= 0x1F5FF)
+                || (cp >= 0x1F680 && cp <= 0x1F6FF)
+                || (cp >= 0x2600 && cp <= 0x26FF)
+                || (cp >= 0x2700 && cp <= 0x27BF)
+                || (cp >= 0xFE00 && cp <= 0xFE0F)
+                || (cp >= 0x1F900 && cp <= 0x1F9FF)
+                || (cp >= 0x1FA70 && cp <= 0x1FAFF)
+                || (cp >= 0x1F1E6 && cp <= 0x1F1FF);
     }
-
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -1,0 +1,25 @@
+package com.noostak.rebuild.member.vo;
+
+public class MemberName {
+
+    private String value;
+
+    private MemberName(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    public static MemberName of(String value) {
+        return new MemberName(value);
+    }
+
+    private void validate(String value) {
+        validateBlank(value);
+    }
+
+    private void validateBlank(String value) {
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("이름은 공백일 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -1,15 +1,24 @@
 package com.noostak.rebuild.member.vo;
 
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+
+@Embeddable
+@EqualsAndHashCode
 public class MemberName {
 
-    private String value;
+    private final String value;
+
+    protected MemberName() {
+        this.value = null;
+    }
 
     private MemberName(String value) {
         validate(value);
         this.value = value;
     }
 
-    public static MemberName of(String value) {
+    public static MemberName from(String value) {
         return new MemberName(value);
     }
 
@@ -19,7 +28,11 @@ public class MemberName {
 
     private void validateBlank(String value) {
         if (value.isBlank()) {
-            throw new IllegalArgumentException("이름은 공백일 수 없습니다.");
+            throw new IllegalArgumentException("이름은 공백으로만 구성될 수 없습니다.");
         }
+    }
+
+    public String value() {
+        return value;
     }
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -7,6 +7,8 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 public class MemberName {
 
+    private static final int MAX_LENGTH = 10;
+
     private final String value;
 
     protected MemberName() {
@@ -28,6 +30,7 @@ public class MemberName {
 
     private void validate(String value) {
         validateNotNullOrBlank(value);
+        validateLength(value);
     }
 
     private void validateNotNullOrBlank(String value) {
@@ -37,6 +40,12 @@ public class MemberName {
 
         if (value.isBlank()) {
             throw new IllegalArgumentException("이름은 공백으로만 구성될 수 없습니다.");
+        }
+    }
+
+    private void validateLength(String value) {
+        if (value.length() > MAX_LENGTH) {
+            throw new IllegalArgumentException("이름은 10자를 초과할 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberName.java
@@ -22,17 +22,21 @@ public class MemberName {
         return new MemberName(value);
     }
 
-    private void validate(String value) {
-        validateBlank(value);
+    public String value() {
+        return value;
     }
 
-    private void validateBlank(String value) {
+    private void validate(String value) {
+        validateNotNullOrBlank(value);
+    }
+
+    private void validateNotNullOrBlank(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("이름은 null 일 수 없습니다.");
+        }
+
         if (value.isBlank()) {
             throw new IllegalArgumentException("이름은 공백으로만 구성될 수 없습니다.");
         }
-    }
-
-    public String value() {
-        return value;
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -85,5 +85,26 @@ class MemberNameTest {
 
             assertThat(memberName.value()).isEqualTo(validName);
         }
+
+        @ParameterizedTest
+        @DisplayName("이름에 다양한 이모지가 포함된 경우 성공적으로 생성된다.")
+        @ValueSource(strings = {
+                "😊",
+                "🚀",
+                "❤️",
+                "🔥수",
+                "🌟리",
+                "😎글",
+                "💡수",
+                "🐱범",
+                "🎉동",
+                "🍕수"
+        })
+        void createMemberNameWithEmoji(String validName) {
+            MemberName memberName = MemberName.from(validName);
+            assertThat(memberName.value()).isEqualTo(validName);
+        }
+
+
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @DisplayName("멤버 이름 테스트")
 class MemberNameTest {
@@ -15,10 +15,12 @@ class MemberNameTest {
     class FailureCases{
 
         @ParameterizedTest
-        @DisplayName("이름이 공백 문자로만 이루어진 경우 실패한다.")
+        @DisplayName("이름이 공백 문자로만 이루어진 경우 예외가 발생한다.")
         @ValueSource(strings = {" ", "   ", "\t", "\n"})
         void nameIsBlank(String invalidName) {
-            assertThrows(IllegalArgumentException.class, () -> MemberName.of(invalidName));
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이름은 공백으로만 구성될 수 없습니다.");
         }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -1,0 +1,27 @@
+package com.noostak.rebuild.member.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("멤버 이름 테스트")
+class MemberNameTest {
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases{
+
+        @ParameterizedTest
+        @DisplayName("이름이 공백으로만 이루어진 경우 실패한다.")
+        @CsvSource({
+                "",
+                " ",
+        })
+        void nameIsBlank(String invalidName) {
+            assertThrows(IllegalArgumentException.class, () -> MemberName.of(invalidName));
+        }
+    }
+}

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -35,12 +36,31 @@ class MemberNameTest {
 
         @ParameterizedTest
         @DisplayName("이름이 10자를 초과하는 경우 예외가 발생한다.")
-        @ValueSource(strings = {"0123467891", "01234567890123456789", "한글과영문혼합길이초과abcde"})
-        void nameLengthExceeded() {
-            String invalidName = "01234567891";
+        @ValueSource(strings = {"01234567891", "01234567890123456789", "한글과영문혼합길이초과abcde"})
+        void nameLengthExceeded(String invalidName) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("이름은 10자를 초과할 수 없습니다.");
+        }
+
+        @ParameterizedTest
+        @DisplayName("이름에 특수문자가 포함된 경우 예외가 발생한다.")
+        @CsvSource({
+                "jsoon@world",
+                "jsoon#world",
+                "jsoon$world",
+                "jsoon%world",
+                "jsoon^world",
+                "jsoon&world",
+                "jsoon*world",
+                "jsoon(world",
+                "jsoon)world",
+                "jsoon-world"
+        })
+        void nameContainsSpecialCharacters(String invalidName) {
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("특수문자는 이름 구성에 포함시킬 수 없습니다.");
         }
     }
 

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -3,7 +3,7 @@ package com.noostak.rebuild.member.vo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -15,11 +15,8 @@ class MemberNameTest {
     class FailureCases{
 
         @ParameterizedTest
-        @DisplayName("이름이 공백으로만 이루어진 경우 실패한다.")
-        @CsvSource({
-                "",
-                " ",
-        })
+        @DisplayName("이름이 공백 문자로만 이루어진 경우 실패한다.")
+        @ValueSource(strings = {" ", "   ", "\t", "\n"})
         void nameIsBlank(String invalidName) {
             assertThrows(IllegalArgumentException.class, () -> MemberName.of(invalidName));
         }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -45,7 +45,7 @@ class MemberNameTest {
 
         @ParameterizedTest
         @DisplayName("이름에 특수문자가 포함된 경우 예외가 발생한다.")
-        @CsvSource({
+        @ValueSource(strings = {
                 "jsoon@worl",
                 "jsoon#word",
                 "jsoon$wold",
@@ -62,6 +62,23 @@ class MemberNameTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("특수문자는 이름 구성에 포함시킬 수 없습니다.");
         }
+
+        @ParameterizedTest
+        @DisplayName("이름에 허용되지 않은 문자(한글, 영문 외 언어)가 포함된 경우 예외가 발생한다.")
+        @ValueSource(strings = {
+                "张伟",
+                "山田太郎",
+                "محمد",
+                "Алексей",
+                "Δημήτρης",
+                "𓀀",
+        })
+        void nameContainsNonKoreanEnglishCharacters(String invalidName) {
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("허용되지 않은 문자가 포함되어 있습니다.");
+        }
+
     }
 
     @Nested

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -2,6 +2,7 @@ package com.noostak.rebuild.member.vo;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -21,6 +22,14 @@ class MemberNameTest {
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("이름은 공백으로만 구성될 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("이름이 null인 경우 예외가 발생한다.")
+        void nameIsNull() {
+            assertThatThrownBy(() -> MemberName.from(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이름은 null 일 수 없습니다.");
         }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -122,6 +122,14 @@ class MemberNameTest {
             assertThat(memberName.value()).isEqualTo(validName);
         }
 
-
+        @ParameterizedTest
+        @DisplayName("이름에 한글, 영문, 숫자가 포함된 경우 성공적으로 생성된다.")
+        @ValueSource(strings = {
+                "권장순", "James", "홍James", "김0순", "kim99", "김Soon9", "so on 9", "이름123", "Name 0"
+        })
+        void createMemberNameWithKoreanEnglishNumber(String validName) {
+            MemberName memberName = MemberName.from(validName);
+            assertThat(memberName.value()).isEqualTo(validName);
+        }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @DisplayName("멤버 이름 테스트")
@@ -32,13 +33,37 @@ class MemberNameTest {
                     .hasMessageContaining("이름은 null 일 수 없습니다.");
         }
 
-        @Test
+        @ParameterizedTest
         @DisplayName("이름이 10자를 초과하는 경우 예외가 발생한다.")
+        @ValueSource(strings = {"0123467891", "01234567890123456789", "한글과영문혼합길이초과abcde"})
         void nameLengthExceeded() {
             String invalidName = "01234567891";
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("이름은 10자를 초과할 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("이름이 공백을 포함하여 10자 이하인 경우 성공적으로 생성된다.")
+        void createMemberNameSuccessfully() {
+            String validName = "j        0";
+            MemberName memberName = MemberName.from(validName);
+
+            assertThat(memberName.value()).isEqualTo(validName);
+        }
+
+        @Test
+        @DisplayName("이름이 10자 이하인 경우 성공적으로 생성된다.")
+        void createMemberNameWithValidLength() {
+            String validName = "jsoonworld";
+            MemberName memberName = MemberName.from(validName);
+
+            assertThat(memberName.value()).isEqualTo(validName);
         }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -31,5 +31,14 @@ class MemberNameTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("이름은 null 일 수 없습니다.");
         }
+
+        @Test
+        @DisplayName("이름이 10자를 초과하는 경우 예외가 발생한다.")
+        void nameLengthExceeded() {
+            String invalidName = "01234567891";
+            assertThatThrownBy(() -> MemberName.from(invalidName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("이름은 10자를 초과할 수 없습니다.");
+        }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -46,16 +46,16 @@ class MemberNameTest {
         @ParameterizedTest
         @DisplayName("이름에 특수문자가 포함된 경우 예외가 발생한다.")
         @CsvSource({
-                "jsoon@world",
-                "jsoon#world",
-                "jsoon$world",
-                "jsoon%world",
-                "jsoon^world",
-                "jsoon&world",
-                "jsoon*world",
-                "jsoon(world",
-                "jsoon)world",
-                "jsoon-world"
+                "jsoon@worl",
+                "jsoon#word",
+                "jsoon$wold",
+                "jsoon%wrld",
+                "jsoon^orld",
+                "jsoon&orld",
+                "jsoo*world",
+                "json(world",
+                "json)world",
+                "joon-world"
         })
         void nameContainsSpecialCharacters(String invalidName) {
             assertThatThrownBy(() -> MemberName.from(invalidName))

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberNameTest.java
@@ -45,40 +45,39 @@ class MemberNameTest {
 
         @ParameterizedTest
         @DisplayName("이름에 특수문자가 포함된 경우 예외가 발생한다.")
-        @ValueSource(strings = {
-                "jsoon@worl",
-                "jsoon#word",
-                "jsoon$wold",
-                "jsoon%wrld",
-                "jsoon^orld",
-                "jsoon&orld",
-                "jsoo*world",
-                "json(world",
-                "json)world",
-                "joon-world"
+        @CsvSource({
+                "jsoon@worl, @",
+                "jsoon#word, #",
+                "jsoon$wold, $",
+                "jsoon%wrld, %",
+                "jsoon^orld, ^",
+                "jsoon&orld, &",
+                "jsoo*world, *",
+                "json(world, (",
+                "json)world, )",
+                "joon-world, -"
         })
-        void nameContainsSpecialCharacters(String invalidName) {
+        void nameContainsSpecialCharacters(String invalidName, String specialChar) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("특수문자는 이름 구성에 포함시킬 수 없습니다.");
+                    .hasMessageContaining("특수문자는 이름 구성에 사용될 수 없습니다.");
         }
 
         @ParameterizedTest
         @DisplayName("이름에 허용되지 않은 문자(한글, 영문 외 언어)가 포함된 경우 예외가 발생한다.")
-        @ValueSource(strings = {
-                "张伟",
-                "山田太郎",
-                "محمد",
-                "Алексей",
-                "Δημήτρης",
-                "𓀀",
+        @CsvSource({
+                "张伟, 张",
+                "山田太郎, 山",
+                "محمد, م",
+                "Алексей, А",
+                "Δημήτρης, Δ",
+                "𓀀, 𓀀"
         })
-        void nameContainsNonKoreanEnglishCharacters(String invalidName) {
+        void nameContainsNonKoreanEnglishCharacters(String invalidName, String invalidChar) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("허용되지 않은 문자가 포함되어 있습니다.");
+                    .hasMessageContaining("허용되지 않은 문자(" + invalidChar + ")가 포함되어 있습니다.");
         }
-
     }
 
     @Nested


### PR DESCRIPTION
# 📄 Work Description  
- `MemberName` `VO` 구현
  - 이름 길이 제한(10자)
  - null, 공백 문자열 검증
  - 특수문자 포함 여부 검증
  - 허용되지 않은 문자(한글, 영문, 숫자, 공백, 이모지 외) 필터링
- `MemberNameTest` 테스트 클래스 구성
  - 성공/실패 케이스 분리
  - 각 검증 포인트별 단위 테스트 작성 및 통과 확인

# 💭 Thoughts  
- 입력값 검증 방식을 화이트리스트 방식과 블랙리스트 방식 중 무엇으로 할지 많이 고민했습니다.  
- 화이트리스트 방식은 허용되는 문자만을 명시하여 비교적 간결하고 효율적인 코드 구성이 가능하다는 장점이 있었지만,  
  새로운 허용 문자가 추가될 때마다 검증 로직을 수정해야 하는 점에서 유지보수에 부담이 있다고 느꼈습니다.  
- 반면 블랙리스트 방식은 포함되어서는 안 되는 문자만 명시하는 방식으로,  
  코드 양은 다소 늘어나더라도 변경과 확장이 용이하고,  
  특정 문자에 대해 보다 명확하게 에러 메시지를 분기할 수 있어 예외 처리 측면에서도 유리하다고 판단했습니다.  
- 결과적으로 **검증 로직의 명확성과 유지보수성**을 우선하여 블랙리스트 방식 기반의 코드로 작성했습니다.

# ✅ Testing Result  
![스크린샷 2025-04-07 오후 6 17 20](https://github.com/user-attachments/assets/a2e602ae-03e9-443e-8edf-baba5ef88e37)


# 🗂 Related Issue  
- closed #3 
