### PR TITLE
[✨ feat] 멤버 프로파일 이미지 키 구현

### DIFF
--- a/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
@@ -8,7 +8,7 @@ import lombok.EqualsAndHashCode;
 public class MemberProfileImageKey {
 
     private static final String DEFAULT_KEY = "default/profile.png";
-    public static final MemberProfileImageKey DEFAULT = new MemberProfileImageKey(DEFAULT_KEY, false);
+    public static final MemberProfileImageKey DEFAULT = new MemberProfileImageKey(DEFAULT_KEY, false); // 검증 생략
 
     private final String value;
 
@@ -17,13 +17,11 @@ public class MemberProfileImageKey {
     }
 
     private MemberProfileImageKey(String value) {
-        this(value, true);
+        validate(value);
+        this.value = value;
     }
 
-    private MemberProfileImageKey(String value, boolean validate) {
-        if (validate) {
-            validate(value);
-        }
+    private MemberProfileImageKey(String value, boolean skipValidation) {
         this.value = value;
     }
 
@@ -35,7 +33,7 @@ public class MemberProfileImageKey {
         if (value == null || value.isBlank()) {
             return DEFAULT;
         }
-        return new MemberProfileImageKey(value);
+        return from(value);
     }
 
     public String value() {
@@ -46,9 +44,21 @@ public class MemberProfileImageKey {
         return DEFAULT_KEY.equals(this.value);
     }
 
-    private void validate(String value) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("프로필 이미지 키는 null 또는 빈 문자열일 수 없습니다.");
+    private static void validate(String value) {
+        validateNotNull(value);
+        validateNotBlank(value);
+    }
+
+    private static void validateNotNull(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("프로필 이미지 키는 null 일 수 없습니다.");
         }
     }
+
+    private static void validateNotBlank(String value) {
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
@@ -27,12 +27,16 @@ public class MemberProfileImageKey {
     }
 
     private void validate(String value) {
-        validateNotNull(value);
+        validateNotNullOrBlank(value);
     }
 
-    private void validateNotNull(String value) {
+    private void validateNotNullOrBlank(String value) {
         if (value == null) {
             throw new IllegalArgumentException("프로필 이미지 키는 null 일 수 없습니다.");
+        }
+
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
@@ -1,4 +1,38 @@
 package com.noostak.rebuild.member.vo;
 
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+
+@Embeddable
+@EqualsAndHashCode
 public class MemberProfileImageKey {
+
+    private final String value;
+
+    protected MemberProfileImageKey() {
+        this.value = null;
+    }
+
+    private MemberProfileImageKey(String value) {
+        validate(value);
+        this.value = value;
+    }
+
+    public static MemberProfileImageKey from(String value) {
+        return new MemberProfileImageKey(value);
+    }
+
+    public String value() {
+        return value;
+    }
+
+    private void validate(String value) {
+        validateNotNull(value);
+    }
+
+    private void validateNotNull(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("프로필 이미지 키는 null 일 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
@@ -1,0 +1,4 @@
+package com.noostak.rebuild.member.vo;
+
+public class MemberProfileImageKey {
+}

--- a/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/vo/MemberProfileImageKey.java
@@ -7,6 +7,9 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 public class MemberProfileImageKey {
 
+    private static final String DEFAULT_KEY = "default/profile.png";
+    public static final MemberProfileImageKey DEFAULT = new MemberProfileImageKey(DEFAULT_KEY, false);
+
     private final String value;
 
     protected MemberProfileImageKey() {
@@ -14,7 +17,13 @@ public class MemberProfileImageKey {
     }
 
     private MemberProfileImageKey(String value) {
-        validate(value);
+        this(value, true);
+    }
+
+    private MemberProfileImageKey(String value, boolean validate) {
+        if (validate) {
+            validate(value);
+        }
         this.value = value;
     }
 
@@ -22,21 +31,24 @@ public class MemberProfileImageKey {
         return new MemberProfileImageKey(value);
     }
 
+    public static MemberProfileImageKey fromOrDefault(String value) {
+        if (value == null || value.isBlank()) {
+            return DEFAULT;
+        }
+        return new MemberProfileImageKey(value);
+    }
+
     public String value() {
         return value;
     }
 
-    private void validate(String value) {
-        validateNotNullOrBlank(value);
+    public boolean isDefault() {
+        return DEFAULT_KEY.equals(this.value);
     }
 
-    private void validateNotNullOrBlank(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException("프로필 이미지 키는 null 일 수 없습니다.");
-        }
-
-        if (value.isBlank()) {
-            throw new IllegalArgumentException("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+    private void validate(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("프로필 이미지 키는 null 또는 빈 문자열일 수 없습니다.");
         }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @DisplayName("멤버 프로필 이미지 키 테스트")
@@ -35,6 +36,53 @@ class MemberProfileImageKeyTest {
             assertThatThrownBy(() -> MemberProfileImageKey.from(key))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("정상적인 키가 주어졌을 때 객체가 생성된다.")
+        void validKey() {
+            String key = "profile/images/user123.png";
+
+            MemberProfileImageKey imageKey = MemberProfileImageKey.from(key);
+
+            assertThat(imageKey.value()).isEqualTo(key);
+        }
+
+        @Test
+        @DisplayName("fromOrDefault에 null이 입력되면 기본 키가 반환된다.")
+        void fromOrDefaultWithNull() {
+            MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault(null);
+
+            assertThat(imageKey).isEqualTo(MemberProfileImageKey.DEFAULT);
+        }
+
+        @Test
+        @DisplayName("fromOrDefault에 빈 문자열이 입력되면 기본 키가 반환된다.")
+        void fromOrDefaultWithBlank() {
+            MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault("   ");
+
+            assertThat(imageKey).isEqualTo(MemberProfileImageKey.DEFAULT);
+        }
+
+        @Test
+        @DisplayName("기본 키는 isDefault()가 true를 반환한다.")
+        void isDefaultTrue() {
+            MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault(null);
+
+            assertThat(imageKey.isDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("사용자 키는 isDefault()가 false를 반환한다.")
+        void isDefaultFalse() {
+            MemberProfileImageKey imageKey = MemberProfileImageKey.from("profile/images/custom.png");
+
+            assertThat(imageKey.isDefault()).isFalse();
         }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
@@ -24,5 +24,17 @@ class MemberProfileImageKeyTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("프로필 이미지 키는 null 일 수 없습니다.");
         }
+
+        @Test
+        @DisplayName("프로필 이미지 키가 빈 문자열인 경우 예외가 발생한다.")
+        void emptyKey() {
+            // given
+            String key = "";
+
+            // when & then
+            assertThatThrownBy(() -> MemberProfileImageKey.from(key))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+        }
     }
 }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
@@ -23,7 +23,7 @@ class MemberProfileImageKeyTest {
             // when & then
             assertThatThrownBy(() -> MemberProfileImageKey.from(key))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("프로필 이미지 키는 null 일 수 없습니다.");
+                    .hasMessage("프로필 이미지 키는 null 일 수 없습니다.");
         }
 
         @Test
@@ -35,7 +35,7 @@ class MemberProfileImageKeyTest {
             // when & then
             assertThatThrownBy(() -> MemberProfileImageKey.from(key))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+                    .hasMessage("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
         }
     }
 
@@ -46,42 +46,53 @@ class MemberProfileImageKeyTest {
         @Test
         @DisplayName("정상적인 키가 주어졌을 때 객체가 생성된다.")
         void validKey() {
+            // given
             String key = "profile/images/user123.png";
 
+            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.from(key);
 
+            // then
             assertThat(imageKey.value()).isEqualTo(key);
         }
 
         @Test
         @DisplayName("fromOrDefault에 null이 입력되면 기본 키가 반환된다.")
         void fromOrDefaultWithNull() {
+            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault(null);
 
+            // then
             assertThat(imageKey).isEqualTo(MemberProfileImageKey.DEFAULT);
         }
 
         @Test
-        @DisplayName("fromOrDefault에 빈 문자열이 입력되면 기본 키가 반환된다.")
+        @DisplayName("fromOrDefault에 공백 문자열이 입력되면 기본 키가 반환된다.")
         void fromOrDefaultWithBlank() {
+            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault("   ");
 
+            // then
             assertThat(imageKey).isEqualTo(MemberProfileImageKey.DEFAULT);
         }
 
         @Test
         @DisplayName("기본 키는 isDefault()가 true를 반환한다.")
         void isDefaultTrue() {
+            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault(null);
 
+            // then
             assertThat(imageKey.isDefault()).isTrue();
         }
 
         @Test
         @DisplayName("사용자 키는 isDefault()가 false를 반환한다.")
         void isDefaultFalse() {
+            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.from("profile/images/custom.png");
 
+            // then
             assertThat(imageKey.isDefault()).isFalse();
         }
     }

--- a/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/com/noostak/rebuild/member/vo/MemberProfileImageKeyTest.java
@@ -1,0 +1,28 @@
+package com.noostak.rebuild.member.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@DisplayName("멤버 프로필 이미지 키 테스트")
+class MemberProfileImageKeyTest {
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("프로필 이미지 키가 null인 경우 예외가 발생한다.")
+        void nullKey() {
+            // given
+            String key = null;
+
+            // when & then
+            assertThatThrownBy(() -> MemberProfileImageKey.from(key))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("프로필 이미지 키는 null 일 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- MemberProfileImageKey Value Object를 구현했습니다.
- null 또는 빈 문자열 입력 시 예외가 발생하도록 검증 로직을 추가했습니다.
- 프로필 이미지가 없는 경우를 위한 기본 키(default/profile.png)를 상수로 정의하고, fromOrDefault 정적 팩토리 메서드를 통해 처리할 수 있도록 했습니다.
- isDefault() 메서드를 통해 기본 이미지 여부를 확인할 수 있도록 했습니다.

# 💭 Thoughts 
- null/blank 입력에 대한 처리 방식을 사용하는 쪽에서 명확하게 협력할 수 있도록 개선하고자 했습니다.
- from과 fromOrDefault로 역할을 분리하면서도, 객체 생성 시 검증을 명확하게 하기 위해 생성자 분기(skipValidation)를 도입했습니다.
- 기본값을 객체 내부에서 직접 관리하되, 사용하는 쪽은 명확한 메시지와 협업으로 처리 가능하도록 구성했습니다.

# ✅ Testing Result  
![스크린샷 2025-04-07 오후 7 12 23](https://github.com/user-attachments/assets/e76743d5-b595-4d58-a114-72e90831b793)


# 🗂 Related Issue  
- closed #5 
