### PR TITLE
[✨ feat] 글로벌 예외 처리 및 도메인별 커스텀 예외 설계 

### DIFF
--- a/src/main/java/com/noostak/rebuild/global/exception/BaseException.java
+++ b/src/main/java/com/noostak/rebuild/global/exception/BaseException.java
@@ -1,0 +1,20 @@
+package com.noostak.rebuild.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BaseException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BaseException(ErrorCode errorCode, Object... args) {
+        super(errorCode.getMessage(args));
+        this.errorCode = errorCode;
+    }
+}
+

--- a/src/main/java/com/noostak/rebuild/global/exception/ErrorCode.java
+++ b/src/main/java/com/noostak/rebuild/global/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.noostak.rebuild.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getRawMessage();
+
+    default String getMessage() {
+        return getRawMessage();
+    }
+
+    default String getMessage(Object... args) {
+        return String.format(getRawMessage(), args);
+    }
+}

--- a/src/main/java/com/noostak/rebuild/global/exception/ErrorResponse.java
+++ b/src/main/java/com/noostak/rebuild/global/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.noostak.rebuild.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final int status;
+    private final String message;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getStatus().value(), errorCode.getMessage());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode.getStatus().value(), message);
+    }
+}

--- a/src/main/java/com/noostak/rebuild/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/noostak/rebuild/global/exception/GlobalErrorCode.java
@@ -1,0 +1,33 @@
+package com.noostak.rebuild.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    public static final String PREFIX = "[GLOBAL ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public String getMessage() {
+        return PREFIX + rawMessage;
+    }
+
+    @Override
+    public String getMessage(Object... args) {
+        return PREFIX + String.format(rawMessage, args);
+    }
+
+    @Override
+    public String getRawMessage() {
+        return rawMessage;
+    }
+}
+

--- a/src/main/java/com/noostak/rebuild/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/noostak/rebuild/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.noostak.rebuild.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BaseException.class)
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException exception) {
+        return ResponseEntity
+                .status(exception.getErrorCode().getStatus())
+                .body(ErrorResponse.of(exception.getErrorCode(), exception.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleInternalServerError(Exception exception) {
+        ErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+}
+

--- a/src/test/java/com/noostak/rebuild/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/noostak/rebuild/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,85 @@
+package com.noostak.rebuild.global.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GlobalExceptionHandler 테스트")
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    static class DummyBaseException extends BaseException {
+        DummyBaseException() {
+            super(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @Nested
+    @DisplayName("BaseException 처리")
+    class HandleBaseException {
+
+        private final DummyBaseException exception = new DummyBaseException();
+        private final ResponseEntity<ErrorResponse> response = handler.handleBaseException(exception);
+
+        @Test
+        @DisplayName("HTTP 상태 코드가 INTERNAL_SERVER_ERROR 이어야 한다")
+        void statusCodeShouldBeInternalServerError() {
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Test
+        @DisplayName("응답 바디가 null이 아니어야 한다")
+        void responseBodyShouldNotBeNull() {
+            assertThat(response.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("ErrorResponse.status 필드는 500 이어야 한다")
+        void errorResponseStatusShouldBe500() {
+            assertThat(response.getBody().getStatus()).isEqualTo(500);
+        }
+
+        @Test
+        @DisplayName("ErrorResponse.message 필드는 정의된 에러 메시지를 포함해야 한다")
+        void errorResponseMessageShouldContainDefinedMessage() {
+            assertThat(response.getBody().getMessage()).contains(GlobalErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("기타 예외 처리")
+    class HandleUnexpectedException {
+
+        private final Exception exception = new IllegalStateException("테스트용 예외");
+        private final ResponseEntity<ErrorResponse> response = handler.handleInternalServerError(exception);
+
+        @Test
+        @DisplayName("HTTP 상태 코드가 INTERNAL_SERVER_ERROR 이어야 한다")
+        void statusCodeShouldBeInternalServerError() {
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Test
+        @DisplayName("응답 바디가 null이 아니어야 한다")
+        void responseBodyShouldNotBeNull() {
+            assertThat(response.getBody()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("ErrorResponse.status 필드는 500 이어야 한다")
+        void errorResponseStatusShouldBe500() {
+            assertThat(response.getBody().getStatus()).isEqualTo(500);
+        }
+
+        @Test
+        @DisplayName("ErrorResponse.message 필드는 글로벌 에러 메시지를 포함해야 한다")
+        void errorResponseMessageShouldContainGlobalErrorMessage() {
+            assertThat(response.getBody().getMessage()).contains(GlobalErrorCode.INTERNAL_SERVER_ERROR.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- 전역(Global) 예외 처리 구조를 설계하고 적용했습니다.  
- `BaseException`을 상속한 커스텀 예외들이 `ErrorCode`를 통해 상태와 메시지를 일관되게 반환할 수 있도록 구조화했습니다.  
- 모든 에러 응답은 `ErrorResponse` DTO로 변환되어 클라이언트에 전달됩니다.  
- 예상치 못한 예외(Exception)는 `GlobalErrorCode.INTERNAL_SERVER_ERROR`로 일괄 처리합니다.  
- 도메인별로 `ErrorCode` 확장 및 예외 정의가 가능한 구조로 분리 설계했습니다.

---

# 💭 Thoughts  
- 예외 메시지를 도메인/글로벌 구분이 가능하도록 `[GLOBAL ERROR]` prefix를 추가해 직관성을 높였습니다.  
- 메시지 포맷 처리 (`Object... args`) 지원을 통해 유연하게 다양한 에러 메시지를 만들 수 있도록 했습니다.  
- 추후 도메인마다 `xxxErrorCode implements ErrorCode`, `xxxException extends BaseException` 패턴으로 확장 예정입니다.  
- 통합 테스트 대신 단위 테스트로 검증하되, 각 필드와 조건을 분리해 책임을 나눈 테스트 구조를 지향했습니다.

---

# ✅ Testing Result  
![스크린샷 2025-04-07 오후 11 40 53](https://github.com/user-attachments/assets/f758b09f-8d19-4b81-9d7b-18b258376d65)

---

# 🗂 Related Issue  
- closed #9 
