### PR TITLE
[✨ feat] 멤버 커스텀 예외를 구현 및 적용 

### DIFF
--- a/src/main/java/com/noostak/rebuild/member/Member.java
+++ b/src/main/java/com/noostak/rebuild/member/Member.java
@@ -1,4 +1,0 @@
-package com.noostak.rebuild.member;
-
-public class Member {
-}

--- a/src/main/java/com/noostak/rebuild/member/domain/Member.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/Member.java
@@ -1,0 +1,4 @@
+package com.noostak.rebuild.member.domain;
+
+public class Member {
+}

--- a/src/main/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatus.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatus.java
@@ -1,12 +1,13 @@
-package com.noostak.rebuild.member.enums;
+package com.noostak.rebuild.member.domain.enums;
+
+import com.noostak.rebuild.member.exception.MemberErrorCode;
+import com.noostak.rebuild.member.exception.MemberException;
 
 import java.util.Arrays;
 
 public enum MemberAccountStatus {
     ACTIVE("활성"),
     INACTIVE("비활성");
-
-    private static final String INVALID_STATUS_MESSAGE = "존재하지 않는 계정 상태입니다";
 
     private final String value;
 
@@ -19,7 +20,7 @@ public enum MemberAccountStatus {
         return Arrays.stream(values())
                 .filter(status -> status.name().equalsIgnoreCase(value))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(INVALID_STATUS_MESSAGE + ": " + value));
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_ACCOUNT_STATUS));
     }
 
     public String value() {
@@ -36,10 +37,10 @@ public enum MemberAccountStatus {
 
     private static void validate(String value) {
         if (value == null) {
-            throw new IllegalArgumentException("계정 상태는 null 일 수 없습니다.");
+            throw new MemberException(MemberErrorCode.NULL_ACCOUNT_STATUS);
         }
         if (value.isBlank()) {
-            throw new IllegalArgumentException("계정 상태는 공백일 수 없습니다.");
+            throw new MemberException(MemberErrorCode.BLANK_ACCOUNT_STATUS);
         }
     }
 }

--- a/src/main/java/com/noostak/rebuild/member/domain/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/vo/MemberName.java
@@ -1,5 +1,7 @@
-package com.noostak.rebuild.member.vo;
+package com.noostak.rebuild.member.domain.vo;
 
+import com.noostak.rebuild.member.exception.MemberErrorCode;
+import com.noostak.rebuild.member.exception.MemberException;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 
@@ -37,29 +39,28 @@ public class MemberName {
 
     private void validateNotNullOrBlank(String value) {
         if (value == null) {
-            throw new IllegalArgumentException("이름은 null 일 수 없습니다.");
+            throw new MemberException(MemberErrorCode.NULL_MEMBER_NAME);
         }
 
         if (value.isBlank()) {
-            throw new IllegalArgumentException("이름은 공백으로만 구성될 수 없습니다.");
+            throw new MemberException(MemberErrorCode.BLANK_MEMBER_NAME);
         }
     }
 
     private void validateLength(String value) {
         if (value.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("이름은 10자를 초과할 수 없습니다.");
+            throw new MemberException(MemberErrorCode.TOO_LONG_MEMBER_NAME);
         }
     }
 
     private void validateCharacter(String value) {
         if (value.matches(SPECIAL_CHAR_PATTERN)) {
-            throw new IllegalArgumentException("특수문자는 이름 구성에 사용될 수 없습니다.");
+            throw new MemberException(MemberErrorCode.SPECIAL_CHAR_IN_MEMBER_NAME);
         }
 
         for (int cp : value.codePoints().toArray()) {
             if (isInvalidCharacter(cp)) {
-                String invalidChar = new String(Character.toChars(cp));
-                throw new IllegalArgumentException("이름에 허용되지 않은 문자(" + invalidChar + ")가 포함되어 있습니다.");
+                throw new MemberException(MemberErrorCode.INVALID_CHAR_IN_MEMBER_NAME);
             }
         }
     }

--- a/src/main/java/com/noostak/rebuild/member/domain/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/vo/MemberProfileImageKey.java
@@ -1,5 +1,7 @@
-package com.noostak.rebuild.member.vo;
+package com.noostak.rebuild.member.domain.vo;
 
+import com.noostak.rebuild.member.exception.MemberErrorCode;
+import com.noostak.rebuild.member.exception.MemberException;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 
@@ -8,7 +10,7 @@ import lombok.EqualsAndHashCode;
 public class MemberProfileImageKey {
 
     private static final String DEFAULT_KEY = "default/profile.png";
-    public static final MemberProfileImageKey DEFAULT = new MemberProfileImageKey(DEFAULT_KEY, false); // 검증 생략
+    public static final MemberProfileImageKey DEFAULT = new MemberProfileImageKey(DEFAULT_KEY, false);
 
     private final String value;
 
@@ -51,14 +53,13 @@ public class MemberProfileImageKey {
 
     private static void validateNotNull(String value) {
         if (value == null) {
-            throw new IllegalArgumentException("프로필 이미지 키는 null 일 수 없습니다.");
+            throw new MemberException(MemberErrorCode.NULL_PROFILE_IMAGE_KEY);
         }
     }
 
     private static void validateNotBlank(String value) {
         if (value.isBlank()) {
-            throw new IllegalArgumentException("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+            throw new MemberException(MemberErrorCode.BLANK_PROFILE_IMAGE_KEY);
         }
     }
-
 }

--- a/src/main/java/com/noostak/rebuild/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/noostak/rebuild/member/exception/MemberErrorCode.java
@@ -1,0 +1,38 @@
+package com.noostak.rebuild.member.exception;
+
+import com.noostak.rebuild.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+    INVALID_ACCOUNT_STATUS(HttpStatus.BAD_REQUEST, "존재하지 않는 계정 상태입니다."),
+    NULL_ACCOUNT_STATUS(HttpStatus.BAD_REQUEST, "계정 상태는 null일 수 없습니다."),
+    BLANK_ACCOUNT_STATUS(HttpStatus.BAD_REQUEST, "계정 상태는 공백일 수 없습니다."),
+
+    NULL_MEMBER_NAME(HttpStatus.BAD_REQUEST, "이름은 null일 수 없습니다."),
+    BLANK_MEMBER_NAME(HttpStatus.BAD_REQUEST, "이름은 공백으로만 구성될 수 없습니다."),
+    TOO_LONG_MEMBER_NAME(HttpStatus.BAD_REQUEST, "이름은 10자를 초과할 수 없습니다."),
+    SPECIAL_CHAR_IN_MEMBER_NAME(HttpStatus.BAD_REQUEST, "특수문자는 이름 구성에 사용될 수 없습니다."),
+    INVALID_CHAR_IN_MEMBER_NAME(HttpStatus.BAD_REQUEST, "이름에 허용되지 않은 문자가 포함되어 있습니다."),
+
+    NULL_PROFILE_IMAGE_KEY(HttpStatus.BAD_REQUEST, "프로필 이미지 키는 null일 수 없습니다."),
+    BLANK_PROFILE_IMAGE_KEY(HttpStatus.BAD_REQUEST, "프로필 이미지 키는 빈 문자열일 수 없습니다."),
+
+    ;
+
+    public static final String PREFIX = "[MEMBER ERROR] ";
+
+    private final HttpStatus status;
+    private final String rawMessage;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getRawMessage() {
+        return PREFIX + rawMessage;
+    }
+}

--- a/src/main/java/com/noostak/rebuild/member/exception/MemberException.java
+++ b/src/main/java/com/noostak/rebuild/member/exception/MemberException.java
@@ -1,0 +1,9 @@
+package com.noostak.rebuild.member.exception;
+
+import com.noostak.rebuild.global.exception.BaseException;
+
+public class MemberException extends BaseException {
+    public MemberException(MemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/test/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatusTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatusTest.java
@@ -1,11 +1,14 @@
-package com.noostak.rebuild.member.enums;
+package com.noostak.rebuild.member.domain.enums;
 
+import com.noostak.rebuild.member.exception.MemberErrorCode;
+import com.noostak.rebuild.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static com.noostak.rebuild.member.exception.MemberErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("멤버 계정 상태 테스트")
@@ -20,17 +23,17 @@ class MemberAccountStatusTest {
         @ValueSource(strings = {"DEACTIVATED", "BLOCKED", "SLEEP", "탈퇴"})
         void from_InvalidStatus_ThrowsException(String invalidStatus) {
             assertThatThrownBy(() -> MemberAccountStatus.from(invalidStatus))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("존재하지 않는 계정 상태입니다");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.INVALID_ACCOUNT_STATUS.getRawMessage());
         }
 
         @ParameterizedTest
-        @DisplayName("공백 또는 null 상태값 입력 시 예외가 발생한다")
+        @DisplayName("공백 상태값 입력 시 예외가 발생한다")
         @ValueSource(strings = {" ", "  ", "\n", "\t"})
         void from_BlankStatus_ThrowsException(String blankStatus) {
             assertThatThrownBy(() -> MemberAccountStatus.from(blankStatus))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("계정 상태는 공백일 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.BLANK_ACCOUNT_STATUS.getRawMessage());
         }
 
         @ParameterizedTest
@@ -38,10 +41,9 @@ class MemberAccountStatusTest {
         @NullSource
         void from_Null_ThrowsException(String input) {
             assertThatThrownBy(() -> MemberAccountStatus.from(input))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("계정 상태는 null 일 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.NULL_ACCOUNT_STATUS.getRawMessage());
         }
-
     }
 
     @Nested

--- a/src/test/java/com/noostak/rebuild/member/domain/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/vo/MemberNameTest.java
@@ -1,5 +1,7 @@
-package com.noostak.rebuild.member.vo;
+package com.noostak.rebuild.member.domain.vo;
 
+import com.noostak.rebuild.member.exception.MemberErrorCode;
+import com.noostak.rebuild.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,32 +17,36 @@ class MemberNameTest {
 
     @Nested
     @DisplayName("실패 케이스")
-    class FailureCases{
+    class FailureCases {
 
         @ParameterizedTest
         @DisplayName("이름이 공백 문자로만 이루어진 경우 예외가 발생한다.")
         @ValueSource(strings = {" ", "   ", "\t", "\n"})
         void nameIsBlank(String invalidName) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름은 공백으로만 구성될 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.BLANK_MEMBER_NAME.getRawMessage());
         }
 
         @Test
         @DisplayName("이름이 null인 경우 예외가 발생한다.")
         void nameIsNull() {
             assertThatThrownBy(() -> MemberName.from(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름은 null 일 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.NULL_MEMBER_NAME.getRawMessage());
         }
 
         @ParameterizedTest
         @DisplayName("이름이 10자를 초과하는 경우 예외가 발생한다.")
-        @ValueSource(strings = {"01234567891", "01234567890123456789", "한글과영문혼합길이초과abcde"})
+        @ValueSource(strings = {
+                "01234567891",
+                "01234567890123456789",
+                "한글과영문혼합길이초과abcde"
+        })
         void nameLengthExceeded(String invalidName) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("이름은 10자를 초과할 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.TOO_LONG_MEMBER_NAME.getRawMessage());
         }
 
         @ParameterizedTest
@@ -59,8 +65,8 @@ class MemberNameTest {
         })
         void nameContainsSpecialCharacters(String invalidName, String specialChar) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("특수문자는 이름 구성에 사용될 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.SPECIAL_CHAR_IN_MEMBER_NAME.getRawMessage());
         }
 
         @ParameterizedTest
@@ -75,8 +81,8 @@ class MemberNameTest {
         })
         void nameContainsNonKoreanEnglishCharacters(String invalidName, String invalidChar) {
             assertThatThrownBy(() -> MemberName.from(invalidName))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("허용되지 않은 문자(" + invalidChar + ")가 포함되어 있습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.INVALID_CHAR_IN_MEMBER_NAME.getRawMessage());
         }
     }
 

--- a/src/test/java/com/noostak/rebuild/member/domain/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/vo/MemberProfileImageKeyTest.java
@@ -1,5 +1,7 @@
-package com.noostak.rebuild.member.vo;
+package com.noostak.rebuild.member.domain.vo;
 
+import com.noostak.rebuild.member.exception.MemberErrorCode;
+import com.noostak.rebuild.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,8 +24,8 @@ class MemberProfileImageKeyTest {
 
             // when & then
             assertThatThrownBy(() -> MemberProfileImageKey.from(key))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("프로필 이미지 키는 null 일 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.NULL_PROFILE_IMAGE_KEY.getRawMessage());
         }
 
         @Test
@@ -34,8 +36,8 @@ class MemberProfileImageKeyTest {
 
             // when & then
             assertThatThrownBy(() -> MemberProfileImageKey.from(key))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("프로필 이미지 키는 빈 문자열 일 수 없습니다.");
+                    .isInstanceOf(MemberException.class)
+                    .hasMessageContaining(MemberErrorCode.BLANK_PROFILE_IMAGE_KEY.getRawMessage());
         }
     }
 
@@ -46,53 +48,36 @@ class MemberProfileImageKeyTest {
         @Test
         @DisplayName("정상적인 키가 주어졌을 때 객체가 생성된다.")
         void validKey() {
-            // given
             String key = "profile/images/user123.png";
-
-            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.from(key);
-
-            // then
             assertThat(imageKey.value()).isEqualTo(key);
         }
 
         @Test
         @DisplayName("fromOrDefault에 null이 입력되면 기본 키가 반환된다.")
         void fromOrDefaultWithNull() {
-            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault(null);
-
-            // then
             assertThat(imageKey).isEqualTo(MemberProfileImageKey.DEFAULT);
         }
 
         @Test
         @DisplayName("fromOrDefault에 공백 문자열이 입력되면 기본 키가 반환된다.")
         void fromOrDefaultWithBlank() {
-            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault("   ");
-
-            // then
             assertThat(imageKey).isEqualTo(MemberProfileImageKey.DEFAULT);
         }
 
         @Test
         @DisplayName("기본 키는 isDefault()가 true를 반환한다.")
         void isDefaultTrue() {
-            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.fromOrDefault(null);
-
-            // then
             assertThat(imageKey.isDefault()).isTrue();
         }
 
         @Test
         @DisplayName("사용자 키는 isDefault()가 false를 반환한다.")
         void isDefaultFalse() {
-            // when
             MemberProfileImageKey imageKey = MemberProfileImageKey.from("profile/images/custom.png");
-
-            // then
             assertThat(imageKey.isDefault()).isFalse();
         }
     }


### PR DESCRIPTION
# 📄 Work Description

- 멤버 도메인 전용 예외 처리 구조를 도입했습니다.
- `IllegalArgumentException` 기반 검증 로직을 `MemberException` + `MemberErrorCode` 기반으로 리팩토링했습니다.
- 다음 도메인 요소에 커스텀 예외 적용:
  - `MemberAccountStatus`
  - `MemberName`
  - `MemberProfileImageKey`
- 각 클래스의 테스트 코드에서 메시지 하드코딩 제거 및 `MemberErrorCode.getRawMessage()` 기반 검증으로 통일
- `vo`, `enums`, `test` 클래스들도 모두 도메인 기준으로 패키지 정리 (`member → member.domain.*`)


# 💭 Thoughts

- `MemberProfileImageKey`는 `DEFAULT_KEY`를 상수로 들고 있고, `fromOrDefault()`와 `isDefault()`를 통해 내부에서 특별한 분기 처리를 하고 있는데,  
  이 구조가 **다소 직관적이지 않고 가시성도 떨어지는 느낌**이 있습니다.  
  특히, 생성자에서 `skipValidation`이라는 boolean 플래그로 분기 처리하는 것도 코드 가독성과 유지보수에 있어 약간 부담입니다.

🔍 **고민 중인 방향**
- `DefaultKey` 자체를 별도의 객체로 분리해서 `KeyPolicy`처럼 위임할지
- 아니면 정적 팩토리 메서드를 더 명시적으로 만들지 (`MemberProfileImageKey.defaultKey()` 등)
- 또는 `Enum`이나 `Wrapper`로 더 명확히 표현할 수 있을지도 고려 중입니다.

# ✅ Testing Result
![스크린샷 2025-04-08 오후 6 29 27](https://github.com/user-attachments/assets/e52133d6-08b9-4e89-a45f-a1154a4bc215)




# 🗂 Related Issue
- closes #11