### PR TITLE
[✨ feat] 멤버 엔티티 구현

### DIFF
--- a/src/main/java/com/noostak/rebuild/member/domain/Member.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/Member.java
@@ -1,4 +1,0 @@
-package com.noostak.rebuild.member.domain;
-
-public class Member {
-}

--- a/src/main/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatus.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatus.java
@@ -1,7 +1,7 @@
 package com.noostak.rebuild.member.domain.enums;
 
-import com.noostak.rebuild.member.exception.MemberErrorCode;
-import com.noostak.rebuild.member.exception.MemberException;
+import com.noostak.rebuild.member.domain.exception.MemberErrorCode;
+import com.noostak.rebuild.member.domain.exception.MemberException;
 
 import java.util.Arrays;
 

--- a/src/main/java/com/noostak/rebuild/member/domain/exception/MemberErrorCode.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/exception/MemberErrorCode.java
@@ -1,4 +1,4 @@
-package com.noostak.rebuild.member.exception;
+package com.noostak.rebuild.member.domain.exception;
 
 import com.noostak.rebuild.global.exception.ErrorCode;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/noostak/rebuild/member/domain/exception/MemberException.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/exception/MemberException.java
@@ -1,4 +1,4 @@
-package com.noostak.rebuild.member.exception;
+package com.noostak.rebuild.member.domain.exception;
 
 import com.noostak.rebuild.global.exception.BaseException;
 

--- a/src/main/java/com/noostak/rebuild/member/domain/model/Member.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/model/Member.java
@@ -1,0 +1,4 @@
+package com.noostak.rebuild.member.domain.model;
+
+public class Member {
+}

--- a/src/main/java/com/noostak/rebuild/member/domain/model/vo/MemberName.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/model/vo/MemberName.java
@@ -1,7 +1,7 @@
-package com.noostak.rebuild.member.domain.vo;
+package com.noostak.rebuild.member.domain.model.vo;
 
-import com.noostak.rebuild.member.exception.MemberErrorCode;
-import com.noostak.rebuild.member.exception.MemberException;
+import com.noostak.rebuild.member.domain.exception.MemberErrorCode;
+import com.noostak.rebuild.member.domain.exception.MemberException;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 

--- a/src/main/java/com/noostak/rebuild/member/domain/model/vo/MemberProfileImageKey.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/model/vo/MemberProfileImageKey.java
@@ -1,7 +1,7 @@
-package com.noostak.rebuild.member.domain.vo;
+package com.noostak.rebuild.member.domain.model.vo;
 
-import com.noostak.rebuild.member.exception.MemberErrorCode;
-import com.noostak.rebuild.member.exception.MemberException;
+import com.noostak.rebuild.member.domain.exception.MemberErrorCode;
+import com.noostak.rebuild.member.domain.exception.MemberException;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 

--- a/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaEntity.java
+++ b/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaEntity.java
@@ -1,0 +1,39 @@
+package com.noostak.rebuild.member.infrastructure.persistence;
+
+import com.noostak.rebuild.member.domain.enums.MemberAccountStatus;
+import com.noostak.rebuild.member.domain.model.vo.MemberName;
+import com.noostak.rebuild.member.domain.model.vo.MemberProfileImageKey;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "members")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "name"))
+    private MemberName name;
+
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(name = "profile_image_key"))
+    private MemberProfileImageKey profileImageKey;
+
+    @Enumerated(EnumType.STRING)
+    private MemberAccountStatus accountStatus;
+
+    private MemberJpaEntity(MemberName name, MemberProfileImageKey profileImageKey, MemberAccountStatus accountStatus) {
+        this.name = name;
+        this.profileImageKey = profileImageKey;
+        this.accountStatus = accountStatus;
+    }
+
+    public static MemberJpaEntity of(MemberName name, MemberProfileImageKey profileImageKey, MemberAccountStatus accountStatus) {
+        return new MemberJpaEntity(name, profileImageKey, accountStatus);
+    }
+}

--- a/src/test/java/com/noostak/rebuild/member/MemberTest.java
+++ b/src/test/java/com/noostak/rebuild/member/MemberTest.java
@@ -1,7 +1,0 @@
-package com.noostak.rebuild.member;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class MemberTest {
-
-}

--- a/src/test/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatusTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/enums/MemberAccountStatusTest.java
@@ -1,14 +1,13 @@
 package com.noostak.rebuild.member.domain.enums;
 
-import com.noostak.rebuild.member.exception.MemberErrorCode;
-import com.noostak.rebuild.member.exception.MemberException;
+import com.noostak.rebuild.member.domain.exception.MemberErrorCode;
+import com.noostak.rebuild.member.domain.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static com.noostak.rebuild.member.exception.MemberErrorCode.*;
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("멤버 계정 상태 테스트")

--- a/src/test/java/com/noostak/rebuild/member/domain/model/MemberTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/model/MemberTest.java
@@ -1,0 +1,5 @@
+package com.noostak.rebuild.member.domain.model;
+
+class MemberTest {
+
+}

--- a/src/test/java/com/noostak/rebuild/member/domain/model/vo/MemberNameTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/model/vo/MemberNameTest.java
@@ -1,7 +1,8 @@
-package com.noostak.rebuild.member.domain.vo;
+package com.noostak.rebuild.member.domain.model.vo;
 
-import com.noostak.rebuild.member.exception.MemberErrorCode;
-import com.noostak.rebuild.member.exception.MemberException;
+import com.noostak.rebuild.member.domain.model.vo.MemberName;
+import com.noostak.rebuild.member.domain.exception.MemberErrorCode;
+import com.noostak.rebuild.member.domain.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/noostak/rebuild/member/domain/model/vo/MemberProfileImageKeyTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/model/vo/MemberProfileImageKeyTest.java
@@ -1,7 +1,8 @@
-package com.noostak.rebuild.member.domain.vo;
+package com.noostak.rebuild.member.domain.model.vo;
 
-import com.noostak.rebuild.member.exception.MemberErrorCode;
-import com.noostak.rebuild.member.exception.MemberException;
+import com.noostak.rebuild.member.domain.model.vo.MemberProfileImageKey;
+import com.noostak.rebuild.member.domain.exception.MemberErrorCode;
+import com.noostak.rebuild.member.domain.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
# 📄 Work Description  
- `Member` 도메인 모델 구조를 개선하고 도메인 계층의 책임을 명확히 분리했습니다.  
- 멤버 도메인 예외(`MemberException`, `MemberErrorCode`)를 `domain.exception` 패키지로 이동  
- VO 객체들(`MemberName`, `MemberProfileImageKey`)을 `domain.model.vo`로 이동  
- `Member` 도메인 클래스를 `domain.model`로 이동  
- 위 변경에 맞춰 테스트 코드도 패키지 구조 정리  
- `MemberJpaEntity` 클래스를 `infrastructure.persistence`에 새로 추가하여 JPA 매핑 구현  

# 💭 Thoughts  
- 도메인 객체와 인프라 객체의 책임을 명확히 분리하기 위해 패키지를 재구성했습니다.  
- 향후 `Member` 도메인 객체와 `MemberJpaEntity` 간 매핑을 담당할 Mapper 또는 Translator 클래스가 필요할 수 있습니다.  

# ✅ Testing Result  
![스크린샷 2025-04-08 오후 8 36 05](https://github.com/user-attachments/assets/8a60a674-898a-4d6b-8b55-b5dea0070d9c)


# 🗂 Related Issue  
- closed #13
