### PR TITLE
[✨ feat] 멤버 도메인 구현 

### DIFF
--- a/src/main/java/com/noostak/rebuild/member/domain/model/Member.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/model/Member.java
@@ -1,4 +1,60 @@
 package com.noostak.rebuild.member.domain.model;
 
+import com.noostak.rebuild.member.domain.enums.MemberAccountStatus;
+import com.noostak.rebuild.member.domain.model.vo.MemberName;
+import com.noostak.rebuild.member.domain.model.vo.MemberProfileImageKey;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
 public class Member {
+
+    private final MemberName name;
+    private final MemberProfileImageKey profileImageKey;
+    private final MemberAccountStatus accountStatus;
+
+    private Member(MemberName name, MemberProfileImageKey profileImageKey, MemberAccountStatus accountStatus) {
+        this.name = name;
+        this.profileImageKey = profileImageKey;
+        this.accountStatus = accountStatus;
+    }
+
+    public static Member of(MemberName name, MemberProfileImageKey profileImageKey, MemberAccountStatus accountStatus) {
+        return new Member(name, profileImageKey, accountStatus);
+    }
+
+    public MemberName name() {
+        return name;
+    }
+
+    public MemberProfileImageKey profileImageKey() {
+        return profileImageKey;
+    }
+
+    public MemberAccountStatus accountStatus() {
+        return accountStatus;
+    }
+
+    public boolean isActive() {
+        return accountStatus.isActive();
+    }
+
+    public boolean isInactive() {
+        return accountStatus.isInactive();
+    }
+
+    public Member activate() {
+        return new Member(name, profileImageKey, MemberAccountStatus.ACTIVE);
+    }
+
+    public Member deactivate() {
+        return new Member(name, profileImageKey, MemberAccountStatus.INACTIVE);
+    }
+
+    public Member updateName(MemberName newName) {
+        return new Member(newName, profileImageKey, accountStatus);
+    }
+
+    public Member updateProfileImageKey(MemberProfileImageKey newProfileImageKey) {
+        return new Member(name, newProfileImageKey, accountStatus);
+    }
 }

--- a/src/test/java/com/noostak/rebuild/member/domain/model/MemberTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/model/MemberTest.java
@@ -1,5 +1,133 @@
 package com.noostak.rebuild.member.domain.model;
 
+import com.noostak.rebuild.member.domain.enums.MemberAccountStatus;
+import com.noostak.rebuild.member.domain.model.vo.MemberName;
+import com.noostak.rebuild.member.domain.model.vo.MemberProfileImageKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Member 도메인 테스트")
 class MemberTest {
+
+    private final MemberName name = MemberName.from("장순");
+    private final MemberProfileImageKey profileImageKey = MemberProfileImageKey.from("profile/1.png");
+
+    @Nested
+    @DisplayName("생성 테스트")
+    class Create {
+
+        @Test
+        @DisplayName("정상적으로 생성된다.")
+        void createSuccessfully() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+
+            assertThat(member.name()).isEqualTo(name);
+            assertThat(member.profileImageKey()).isEqualTo(profileImageKey);
+            assertThat(member.accountStatus()).isEqualTo(MemberAccountStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 확인 테스트")
+    class StatusCheck {
+
+        @Test
+        @DisplayName("활성 상태인지 확인할 수 있다.")
+        void isActive() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+            assertThat(member.isActive()).isTrue();
+            assertThat(member.isInactive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("비활성 상태인지 확인할 수 있다.")
+        void isInactive() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.INACTIVE);
+            assertThat(member.isInactive()).isTrue();
+            assertThat(member.isActive()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전환 테스트")
+    class StatusTransition {
+
+        @Test
+        @DisplayName("비활성 상태를 활성으로 전환할 수 있다.")
+        void activate() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.INACTIVE);
+            Member activated = member.activate();
+
+            assertThat(activated.accountStatus()).isEqualTo(MemberAccountStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("활성 상태를 비활성으로 전환할 수 있다.")
+        void deactivate() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+            Member deactivated = member.deactivate();
+
+            assertThat(deactivated.accountStatus()).isEqualTo(MemberAccountStatus.INACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("정보 업데이트 테스트")
+    class Update {
+
+        @Test
+        @DisplayName("이름을 변경할 수 있다.")
+        void updateName() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+            Member updated = member.updateName(MemberName.from("김아름"));
+
+            assertThat(updated.name().value()).isEqualTo("김아름");
+            assertThat(updated.profileImageKey()).isEqualTo(profileImageKey);
+            assertThat(updated.accountStatus()).isEqualTo(MemberAccountStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("프로필 이미지 키를 변경할 수 있다.")
+        void updateProfileImageKey() {
+            Member member = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+            Member updated = member.updateProfileImageKey(MemberProfileImageKey.from("profile/2.png"));
+
+            assertThat(updated.name()).isEqualTo(name);
+            assertThat(updated.profileImageKey().value()).isEqualTo("profile/2.png");
+            assertThat(updated.accountStatus()).isEqualTo(MemberAccountStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("동등성 비교 테스트")
+    class Equality {
+
+        @Test
+        @DisplayName("모든 필드가 같으면 동일한 멤버로 판단한다.")
+        void sameValuesShouldBeEqual() {
+            Member member1 = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+            Member member2 = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+
+            assertThat(member1).isEqualTo(member2);
+            assertThat(member1.hashCode()).isEqualTo(member2.hashCode());
+        }
+
+        @Test
+        @DisplayName("다른 필드가 하나라도 있으면 서로 다른 멤버로 판단한다.")
+        void differentValuesShouldNotBeEqual() {
+            Member differentName = Member.of(MemberName.from("다른이름"), profileImageKey, MemberAccountStatus.ACTIVE);
+            Member differentImageKey = Member.of(name, MemberProfileImageKey.from("diff/key.png"), MemberAccountStatus.ACTIVE);
+            Member differentStatus = Member.of(name, profileImageKey, MemberAccountStatus.INACTIVE);
+
+            Member original = Member.of(name, profileImageKey, MemberAccountStatus.ACTIVE);
+
+            assertThat(original).isNotEqualTo(differentName);
+            assertThat(original).isNotEqualTo(differentImageKey);
+            assertThat(original).isNotEqualTo(differentStatus);
+        }
+    }
 
 }


### PR DESCRIPTION
# 📄 Work Description  
- Member 도메인 모델 구현
  - 이름, 프로필 이미지 키, 계정 상태를 필드로 구성
  - 불변 객체로 설계하여 상태 변경 시 새로운 객체를 반환
  - 도메인 메서드를 통해 활성/비활성 전환, 이름 및 이미지 키 변경 가능
- VO 기반 메시지 협력 구조로 구현하여 내부 구현을 감춤
- equals, hashCode 오버라이드로 상태 기반 동등성 비교 정의

# 💭 Thoughts 
- 도메인 객체의 행위를 중심으로 책임을 나누고, VO에 유효성 검증을 위임함으로써 객체지향적 설계를 적용했습니다.
- 멤버 도메인은 순수하게 비즈니스 로직만 담고, JPA 엔티티와 명확히 분리했습니다.
- 이후 Mapper를 통해 MemberJpaEntity ↔ Member 변환 구조도 도입할 예정입니다.

# ✅ Testing Result  
![스크린샷 2025-04-08 오후 9 28 34](https://github.com/user-attachments/assets/597ae871-4b5c-4044-b1f9-ba000bf6efa2)


# 🗂 Related Issue  
- closed #15 
