### PR TITLE
[✨ feat] 멤버 리포지토리 구현 및 JPA 구현

### DIFF
--- a/src/main/java/com/noostak/rebuild/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/noostak/rebuild/member/domain/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.noostak.rebuild.member.domain.repository;
+
+import com.noostak.rebuild.member.domain.model.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository {
+    Optional<Member> findById(Long id);
+    void save(Member member);
+}

--- a/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaEntity.java
+++ b/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaEntity.java
@@ -5,10 +5,12 @@ import com.noostak.rebuild.member.domain.model.vo.MemberName;
 import com.noostak.rebuild.member.domain.model.vo.MemberProfileImageKey;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "members")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberJpaEntity {
 

--- a/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaEntity.java
+++ b/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaEntity.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "members")
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberJpaEntity {
 
@@ -37,5 +36,17 @@ public class MemberJpaEntity {
 
     public static MemberJpaEntity of(MemberName name, MemberProfileImageKey profileImageKey, MemberAccountStatus accountStatus) {
         return new MemberJpaEntity(name, profileImageKey, accountStatus);
+    }
+
+    public MemberName name() {
+        return name;
+    }
+
+    public MemberProfileImageKey profileImageKey() {
+        return profileImageKey;
+    }
+
+    public MemberAccountStatus accountStatus() {
+        return accountStatus;
     }
 }

--- a/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaRepository.java
+++ b/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberJpaRepository.java
@@ -1,0 +1,27 @@
+package com.noostak.rebuild.member.infrastructure.persistence;
+
+import com.noostak.rebuild.member.domain.model.Member;
+import com.noostak.rebuild.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberJpaRepository implements MemberRepository {
+
+    private final SpringDataMemberJpaRepository springRepository;
+
+    @Override
+    public Optional<Member> findById(Long id) {
+        return springRepository.findById(id)
+                .map(MemberMapper::toDomain);
+    }
+
+    @Override
+    public void save(Member member) {
+        springRepository.save(MemberMapper.toEntity(member));
+    }
+}
+

--- a/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberMapper.java
+++ b/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/MemberMapper.java
@@ -1,0 +1,22 @@
+package com.noostak.rebuild.member.infrastructure.persistence;
+
+import com.noostak.rebuild.member.domain.model.Member;
+
+public class MemberMapper {
+
+    public static Member toDomain(MemberJpaEntity entity) {
+        return Member.of(
+                entity.name(),
+                entity.profileImageKey(),
+                entity.accountStatus()
+        );
+    }
+
+    public static MemberJpaEntity toEntity(Member domain) {
+        return MemberJpaEntity.of(
+                domain.name(),
+                domain.profileImageKey(),
+                domain.accountStatus()
+        );
+    }
+}

--- a/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/SpringDataMemberJpaRepository.java
+++ b/src/main/java/com/noostak/rebuild/member/infrastructure/persistence/SpringDataMemberJpaRepository.java
@@ -1,0 +1,7 @@
+package com.noostak.rebuild.member.infrastructure.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataMemberJpaRepository extends JpaRepository<MemberJpaEntity, Long> {
+}
+

--- a/src/test/java/com/noostak/rebuild/member/domain/repository/FakeMemberRepository.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/repository/FakeMemberRepository.java
@@ -1,0 +1,29 @@
+package com.noostak.rebuild.member.domain.repository;
+
+import com.noostak.rebuild.member.domain.model.Member;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class FakeMemberRepository implements MemberRepository {
+
+    private final Set<Member> storage = new HashSet<>();
+
+    @Override
+    public Optional<Member> findById(Long id) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void save(Member member) {
+        storage.remove(member);
+        storage.add(member);
+    }
+
+    public Optional<Member> findBy(Member target) {
+        return storage.stream()
+                .filter(saved -> saved.equals(target))
+                .findFirst();
+    }
+}

--- a/src/test/java/com/noostak/rebuild/member/domain/repository/FakeMemberRepository.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/repository/FakeMemberRepository.java
@@ -17,11 +17,17 @@ public class FakeMemberRepository implements MemberRepository {
 
     @Override
     public void save(Member member) {
+        if (member == null) {
+            throw new NullPointerException("저장하려는 Member 객체가 null일 수 없습니다.");
+        }
         storage.remove(member);
         storage.add(member);
     }
 
     public Optional<Member> findBy(Member target) {
+        if (target == null) {
+            throw new NullPointerException("조회하려는 Member 객체가 null일 수 없습니다.");
+        }
         return storage.stream()
                 .filter(saved -> saved.equals(target))
                 .findFirst();

--- a/src/test/java/com/noostak/rebuild/member/domain/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/noostak/rebuild/member/domain/repository/MemberRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.noostak.rebuild.member.domain.repository;
+
+import com.noostak.rebuild.member.domain.enums.MemberAccountStatus;
+import com.noostak.rebuild.member.domain.model.Member;
+import com.noostak.rebuild.member.domain.model.vo.MemberName;
+import com.noostak.rebuild.member.domain.model.vo.MemberProfileImageKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("MemberRepository 테스트")
+class MemberRepositoryTest {
+
+    private final FakeMemberRepository repository = new FakeMemberRepository();
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("Member를 저장하고, 같은 정보를 기반으로 조회할 수 있다.")
+        void saveAndRetrieveMember() {
+            // given
+            Member member = Member.of(
+                    MemberName.from("장순"),
+                    MemberProfileImageKey.from("profile-img-key"),
+                    MemberAccountStatus.ACTIVE
+            );
+
+            // when
+            repository.save(member);
+            Optional<Member> result = repository.findBy(member);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(member);
+        }
+
+        @Test
+        @DisplayName("서로 다른 여러 멤버를 저장하고 각각 조회할 수 있다.")
+        void saveMultipleMembersAndRetrieve() {
+            // given
+            Member member1 = Member.of(
+                    MemberName.from("사용자A"),
+                    MemberProfileImageKey.from("img-a"),
+                    MemberAccountStatus.ACTIVE
+            );
+            Member member2 = Member.of(
+                    MemberName.from("사용자B"),
+                    MemberProfileImageKey.from("img-b"),
+                    MemberAccountStatus.INACTIVE
+            );
+
+            // when
+            repository.save(member1);
+            repository.save(member2);
+
+            Optional<Member> result1 = repository.findBy(member1);
+            Optional<Member> result2 = repository.findBy(member2);
+
+            // then
+            assertThat(result1).isPresent();
+            assertThat(result1.get()).isEqualTo(member1);
+
+            assertThat(result2).isPresent();
+            assertThat(result2.get()).isEqualTo(member2);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("존재하지 않는 멤버를 조회하면 빈 Optional을 반환한다.")
+        void findNonExistentMember() {
+            // given
+            Member nonExistentMember = Member.of(
+                    MemberName.from("없는멤버"),
+                    MemberProfileImageKey.from("non-existent-key"),
+                    MemberAccountStatus.ACTIVE
+            );
+
+            // when
+            Optional<Member> result = repository.findBy(nonExistentMember);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null 멤버를 저장하려고 하면 예외가 발생한다.")
+        void saveNullMemberThrowsException() {
+            // given
+            Member nullMember = null;
+
+            // when & then
+            assertThatThrownBy(() -> repository.save(nullMember))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("저장하려는 Member 객체가 null일 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("null 멤버로 조회하려고 하면 예외가 발생한다.")
+        void findByNullMemberThrowsException() {
+            // given
+            Member nullMember = null;
+
+            // when & then
+            assertThatThrownBy(() -> repository.findBy(nullMember))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("조회하려는 Member 객체가 null일 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
# 📄 Work Description  
- MemberRepository 인터페이스 정의  
- MemberJpaEntity 및 SpringDataMemberJpaRepository 구현  
- MemberMapper 추가하여 Entity ↔ Domain 간 변환 로직 처리  
- FakeMemberRepository 구현체로 단위 테스트 용이성 확보  
- MemberRepositoryTest 작성해 저장/조회 로직에 대한 성공·실패 케이스 검증  

# 💭 Thoughts  
- 현재는 NullPointerException을 사용하고 있는데, 추후에는 CustomException (예: MemberException)으로 예외 처리를 개선하면 더 명확하고 깔끔한 코드가 될 것 같아요.

- FakeMemberRepository로 테스트를 잘 진행했지만, 실제 DB와 연결된 통합 테스트도 추가해야 할 것 같아요. 실제 데이터베이스 환경에서 발생할 수 있는 문제들을 더 신중하게 다뤄야 할 것 같습니다.

- MemberJpaEntity와 MemberMapper의 역할은 잘 정의했지만, 데이터베이스와의 연동을 고려할 때 성능 최적화도 필요할 수 있어요. 데이터 저장 방식이나 쿼리 최적화에 대해서도 조금 더 고민해보면 좋을 것 같아요. 

# ✅ Testing Result  
![스크린샷 2025-04-08 오후 11 28 08](https://github.com/user-attachments/assets/f31b0de3-be98-4c9d-95e0-ee62cec398ac)


# 🗂 Related Issue  
- closed #17