### PR TITLE
[✨ feat] 인증 타입 구현 

### DIFF
--- a/src/main/java/com/noostak/rebuild/auth/domain/enums/SocialAuthType.java
+++ b/src/main/java/com/noostak/rebuild/auth/domain/enums/SocialAuthType.java
@@ -20,6 +20,6 @@ public enum SocialAuthType {
         return Arrays.stream(values())
                 .filter(type -> type.provider.equalsIgnoreCase(givenProvider))
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("존재 하지 않는 소셜 로그인 타입입니다."));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 소셜 로그인 타입입니다."));
     }
 }

--- a/src/main/java/com/noostak/rebuild/auth/domain/enums/SocialAuthType.java
+++ b/src/main/java/com/noostak/rebuild/auth/domain/enums/SocialAuthType.java
@@ -1,0 +1,25 @@
+package com.noostak.rebuild.auth.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum SocialAuthType {
+
+    KAKAO("KAKAO"),
+    GOOGLE("GOOGLE"),
+    APPLE("APPLE"),
+    ;
+
+    private final String provider;
+
+    public static SocialAuthType from(String givenProvider) {
+        return Arrays.stream(values())
+                .filter(type -> type.provider.equalsIgnoreCase(givenProvider))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재 하지 않는 소셜 로그인 타입입니다."));
+    }
+}

--- a/src/test/java/com/noostak/rebuild/auth/domain/enums/SocialAuthTypeTest.java
+++ b/src/test/java/com/noostak/rebuild/auth/domain/enums/SocialAuthTypeTest.java
@@ -1,0 +1,57 @@
+package com.noostak.rebuild.auth.domain.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@DisplayName("소셜 인증 타입 테스트")
+class SocialAuthTypeTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @ParameterizedTest
+        @DisplayName("정상적인 소셜 인증 타입 문자열이 주어지면 해당 enum을 반환한다.")
+        @ValueSource(strings = {"KAKAO", "GOOGLE", "APPLE"})
+        void validSocialAuthType(String input) {
+            SocialAuthType result = SocialAuthType.from(input);
+            assertThat(result.getProvider()).isEqualTo(input);
+        }
+
+        @ParameterizedTest
+        @DisplayName("소셜 인증 타입 문자열이 소문자거나 혼합되어 있어도 성공적으로 매핑된다.")
+        @ValueSource(strings = {"kakao", "Google", "aPpLe"})
+        void caseInsensitiveInput(String input) {
+            SocialAuthType result = SocialAuthType.from(input);
+            assertThat(result.getProvider()).isIn("KAKAO", "GOOGLE", "APPLE");
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @ParameterizedTest
+        @DisplayName("존재하지 않는 소셜 인증 타입이면 예외가 발생한다.")
+        @ValueSource(strings = {"FACEBOOK", "NAVER", "TWITTER", "", " ", "goolge", "앱플"})
+        void invalidSocialAuthType(String input) {
+            assertThatThrownBy(() -> SocialAuthType.from(input))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("존재 하지 않는 소셜 로그인 타입입니다.");
+        }
+
+        @Test
+        @DisplayName("null이 주어지면 예외가 발생한다.")
+        void nullInput() {
+            assertThatThrownBy(() -> SocialAuthType.from(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("존재 하지 않는 소셜 로그인 타입입니다.");
+        }
+    }
+}

--- a/src/test/java/com/noostak/rebuild/auth/domain/enums/SocialAuthTypeTest.java
+++ b/src/test/java/com/noostak/rebuild/auth/domain/enums/SocialAuthTypeTest.java
@@ -43,7 +43,7 @@ class SocialAuthTypeTest {
         void invalidSocialAuthType(String input) {
             assertThatThrownBy(() -> SocialAuthType.from(input))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("존재 하지 않는 소셜 로그인 타입입니다.");
+                    .hasMessageContaining("존재하지 않는 소셜 로그인 타입입니다.");
         }
 
         @Test
@@ -51,7 +51,7 @@ class SocialAuthTypeTest {
         void nullInput() {
             assertThatThrownBy(() -> SocialAuthType.from(null))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("존재 하지 않는 소셜 로그인 타입입니다.");
+                    .hasMessageContaining("존재하지 않는 소셜 로그인 타입입니다.");
         }
     }
 }


### PR DESCRIPTION
# 📄 Work Description  
- SocialAuthType enum을 도메인에 정의하여 KAKAO, GOOGLE, APPLE 소셜 로그인 타입을 구분할 수 있도록 구현하였습니다.
- provider 값을 기준으로 문자열 매핑이 가능하며, 대소문자 구분 없이 동작하도록 `equalsIgnoreCase` 적용하였습니다.
- 존재하지 않는 값에 대해서는 `IllegalArgumentException`을 발생시킵니다.

# 💭 Thoughts  
- enum이지만 provider 값으로 비교하는 방식이 향후 provider-specific 속성 추가 시에도 유연하게 확장 가능하다고 판단했습니다.
- 예외는 현재 단순한 런타임 예외로 처리했으며, 추후 AuthException으로 교체 예정입니다.

# ✅ Testing Result  
![스크린샷 2025-04-09 오후 8 40 33](https://github.com/user-attachments/assets/d1ba60b7-7773-4848-81a4-34fcbaf4db20)

# 🗂 Related Issue  
- closed #19
